### PR TITLE
Prevent page refresh if user press Enter on the Duration form input

### DIFF
--- a/app/assets/scripts/components/home/create-pane.js
+++ b/app/assets/scripts/components/home/create-pane.js
@@ -313,7 +313,7 @@ export function CreatePaneBody(props) {
                   onEditClick={() => onAction('camera.edit', { idx })}
                 />
                 {idx < scenes.length - 1 && (
-                  <Form>
+                  <Form onSubmit={(e) => e.preventDefault()}>
                     <FormGroup>
                       <FormGroupHeader>
                         <FormLabel htmlFor='transition-duration'>


### PR DESCRIPTION
The page was refreshing if the user pressed Enter on the Duration input. This PR fixes it.

![image](https://user-images.githubusercontent.com/666291/129481503-b30ec74b-870e-4f5a-85f7-ce3e5bb232c3.png)
